### PR TITLE
Help doesn't show Custom commands anymore

### DIFF
--- a/bin/fin
+++ b/bin/fin
@@ -1240,11 +1240,16 @@ show_help_list_commands_in_help ()
 	else
 		addons_path="$HOME/$DOCKSAL_COMMANDS_PATH"
 	fi
-
-	local addons_list=$(find "$addons_path" -type f -executable 2>/dev/null)
+	
+	local executable="-executable"
+	if [[ is_mac ]]; then
+		executable="-perm +100"
+	fi
+	
+	local addons_list=$(find "$addons_path" -type f ${executable} 2>/dev/null)
 	if [ ! -z "$addons_list" ]; then
 		local scope
-		for cmd_name in $(find "$addons_path" -type f -executable)
+		for cmd_name in $(find "$addons_path" -type f ${executable})
 		do
 			local g
 			[[ "$1" == 'global' ]] && g=' [g]'

--- a/bin/fin
+++ b/bin/fin
@@ -1241,10 +1241,10 @@ show_help_list_commands_in_help ()
 		addons_path="$HOME/$DOCKSAL_COMMANDS_PATH"
 	fi
 
-	local addons_list=$(find "$addons_path" -type f -perm +100 2>/dev/null)
+	local addons_list=$(find "$addons_path" -type f -executable 2>/dev/null)
 	if [ ! -z "$addons_list" ]; then
 		local scope
-		for cmd_name in $(find "$addons_path" -type f -perm +100)
+		for cmd_name in $(find "$addons_path" -type f -executable)
 		do
 			local g
 			[[ "$1" == 'global' ]] && g=' [g]'


### PR DESCRIPTION
In #526 are the find commands changed. At least in Ubuntu I don't see my Custom commands since fin v1.90.

In [find manpage](http://man7.org/linux/man-pages/man1/find.1.html) I find the text:
> -perm +mode
>              This is no longer supported (and has been deprecated since
>              2005).  Use -perm /mode instead.

The idea is to list only executable commands. I have opted to use -executable instead of -perm.